### PR TITLE
Fix bomb placement trapping player and enforce wall collisions

### DIFF
--- a/tests/bomb.test.ts
+++ b/tests/bomb.test.ts
@@ -19,4 +19,15 @@ describe('Bomb', () => {
     game.update(BOMB_TIME + 0.1);
     expect(game.world.get('bomb')[id]).toBeUndefined();
   });
+
+  it('allows player to move after placing', () => {
+    const game = setup();
+    const player = game.world.query('player')[0];
+    game.placeBomb(player);
+    (game as any).input.right = true;
+    game.update(0.2);
+    (game as any).input.right = false;
+    const pos = game.world.get('pos')[player];
+    expect(pos.x).toBeGreaterThan(1);
+  });
 });

--- a/tests/collision.test.ts
+++ b/tests/collision.test.ts
@@ -23,6 +23,8 @@ describe('Collision', () => {
     expect(pass(0,0)).toBe(false); // solid
     expect(pass(2,1)).toBe(false); // breakable
     expect(pass(1,1)).toBe(true); // player tile empty initially
+    expect(pass(-1,1)).toBe(false); // out of bounds left
+    expect(pass(5,1)).toBe(false); // out of bounds right
     const player = game.world.query('player')[0];
     game.placeBomb(player);
     expect(pass(1,1)).toBe(false); // bomb blocks


### PR DESCRIPTION
## Summary
- allow bomb planters to move off their own bomb before it blocks the tile
- prevent movement outside map bounds and update collision checks
- add tests for bomb movement and boundary collisions

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c03c28f483249e5a11e69468d667